### PR TITLE
TypeScript - Fix return type when `immediate` option is set, correctly export interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace debounce {
+declare namespace debounceFn {
 	interface Options {
 		/**
 		Time to wait until the `input` function is called.
@@ -13,6 +13,15 @@ declare namespace debounce {
 		@default false
 		*/
 		readonly immediate?: boolean;
+	}
+
+	interface ImmediateOptions extends Options {
+		readonly immediate: true;
+	}
+
+	interface DebouncedFunction<ArgumentsType extends unknown[], ReturnType> {
+		(...arguments: ArgumentsType): ReturnType;
+		cancel(): void;
 	}
 }
 
@@ -35,7 +44,11 @@ window.onresize = debounceFn(() => {
 */
 declare function debounceFn<ArgumentsType extends unknown[], ReturnType>(
 	input: (...arguments: ArgumentsType) => ReturnType,
-	options?: debounce.Options
-): ((...arguments: ArgumentsType) => ReturnType | undefined) & {cancel(): void};
+	options: debounceFn.ImmediateOptions
+): debounceFn.DebouncedFunction<ArgumentsType, ReturnType>;
+declare function debounceFn<ArgumentsType extends unknown[], ReturnType>(
+	input: (...arguments: ArgumentsType) => ReturnType,
+	options?: debounceFn.Options
+): debounceFn.DebouncedFunction<ArgumentsType, ReturnType | undefined>;
 
 export = debounceFn;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,11 +1,23 @@
-import {expectType} from 'tsd';
+import {expectType, expectError} from 'tsd';
 import debounceFn = require('.');
 
+const options: debounceFn.Options = {};
 const debounced = debounceFn((string: string) => true);
-expectType<((string: string) => boolean | undefined) & {cancel(): void}>(debounced);
+expectType<debounceFn.DebouncedFunction<[string], boolean | undefined>>(
+	debounced
+);
 expectType<boolean | undefined>(debounced('foo'));
 debounced.cancel();
 
-debounceFn((string: string) => true);
-debounceFn((string: string) => true, {wait: 100});
-debounceFn((string: string) => true, {immediate: true});
+const debouncedWithoutOptions = debounceFn((string: string) => true);
+expectType<boolean | undefined>(debouncedWithoutOptions('foo'));
+expectError<boolean>(debouncedWithoutOptions('foo'));
+
+const debouncedWithWait = debounceFn((string: string) => true, {wait: 100});
+expectType<boolean | undefined>(debouncedWithWait('foo'));
+expectError<boolean>(debouncedWithWait('foo'));
+
+const debouncedWithImmediate = debounceFn((string: string) => true, {
+	immediate: true
+});
+expectType<boolean>(debouncedWithImmediate('foo'));


### PR DESCRIPTION
Fixes #7.