### PR TITLE
Add `before` and `after` options, remove `immediate` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,15 +8,27 @@ declare namespace debounceFn {
 		readonly wait?: number;
 
 		/**
-		Trigger the function on the leading edge instead of the trailing edge of the `wait` interval. For example, can be useful for preventing accidental double-clicks on a "submit" button from firing a second time.
+		Trigger the function on leading edge of `wait` interval. For example, can be useful for preventing accidental double-clicks on a "submit" button from firing a second time.
 
 		@default false
 		*/
-		readonly immediate?: boolean;
+		readonly before?: boolean;
+
+		/**
+		Trigger the function on trailing edge of `wait` interval.
+
+		@default true
+		*/
+		readonly after?: boolean;
 	}
 
-	interface ImmediateOptions extends Options {
-		readonly immediate: true;
+	interface BeforeOptions extends Options {
+		readonly before: true;
+	}
+
+	interface NoBeforeNoAfterOptions extends Options {
+		readonly after: false;
+		readonly before?: false;
 	}
 
 	interface DebouncedFunction<ArgumentsType extends unknown[], ReturnType> {
@@ -44,8 +56,14 @@ window.onresize = debounceFn(() => {
 */
 declare function debounceFn<ArgumentsType extends unknown[], ReturnType>(
 	input: (...arguments: ArgumentsType) => ReturnType,
-	options: debounceFn.ImmediateOptions
+	options: debounceFn.BeforeOptions
 ): debounceFn.DebouncedFunction<ArgumentsType, ReturnType>;
+
+declare function debounceFn<ArgumentsType extends unknown[], ReturnType>(
+	input: (...arguments: ArgumentsType) => ReturnType,
+	options: debounceFn.NoBeforeNoAfterOptions
+): debounceFn.DebouncedFunction<ArgumentsType, undefined>;
+
 declare function debounceFn<ArgumentsType extends unknown[], ReturnType>(
 	input: (...arguments: ArgumentsType) => ReturnType,
 	options?: debounceFn.Options

--- a/index.js
+++ b/index.js
@@ -9,6 +9,10 @@ module.exports = (fn, options = {}) => {
 	const before = (options.before === undefined) ? false : options.before;
 	const after = (options.after === undefined) ? true : options.after;
 
+	if (!before && !after) {
+		throw new Error('Both `before` and `after` are false, function wouldn\'t be called.');
+	}
+
 	let timeout;
 	let result;
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ module.exports = (fn, options = {}) => {
 		throw new TypeError(`Expected the first argument to be a function, got \`${typeof fn}\``);
 	}
 
+	const before = (options.before === undefined) ? false : options.before;
+	const after = (options.after === undefined) ? true : options.after;
+
 	let timeout;
 	let result;
 
@@ -14,12 +17,12 @@ module.exports = (fn, options = {}) => {
 
 		const later = () => {
 			timeout = null;
-			if (!options.immediate) {
+			if (after) {
 				result = fn.apply(context, args);
 			}
 		};
 
-		const callNow = options.immediate && !timeout;
+		const callNow = before && !timeout;
 		clearTimeout(timeout);
 		timeout = setTimeout(later, options.wait || 0);
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,23 +1,24 @@
 import {expectType, expectError} from 'tsd';
 import debounceFn = require('.');
 
+const stringToBoolean = (string: string) => true;
+
 const options: debounceFn.Options = {};
-const debounced = debounceFn((string: string) => true);
-expectType<debounceFn.DebouncedFunction<[string], boolean | undefined>>(
-	debounced
-);
+const debounced = debounceFn(stringToBoolean);
+expectType<debounceFn.DebouncedFunction<[string], boolean | undefined>>(debounced);
 expectType<boolean | undefined>(debounced('foo'));
 debounced.cancel();
 
-const debouncedWithoutOptions = debounceFn((string: string) => true);
-expectType<boolean | undefined>(debouncedWithoutOptions('foo'));
-expectError<boolean>(debouncedWithoutOptions('foo'));
+expectType<boolean | undefined>(debounceFn(stringToBoolean)('foo'));
+expectError<boolean>(debounceFn(stringToBoolean)('foo'));
 
-const debouncedWithWait = debounceFn((string: string) => true, {wait: 100});
-expectType<boolean | undefined>(debouncedWithWait('foo'));
-expectError<boolean>(debouncedWithWait('foo'));
+expectType<boolean | undefined>(debounceFn(stringToBoolean, {wait: 20})('foo'));
+expectError<boolean>(debounceFn(stringToBoolean, {wait: 20})('foo'));
+expectType<boolean | undefined>(debounceFn(stringToBoolean, {after: true})('foo'));
+expectError<boolean>(debounceFn(stringToBoolean, {after: true})('foo'));
 
-const debouncedWithImmediate = debounceFn((string: string) => true, {
-	immediate: true
-});
-expectType<boolean>(debouncedWithImmediate('foo'));
+expectType<boolean>(debounceFn(stringToBoolean, {before: true})('foo'));
+expectType<boolean>(debounceFn(stringToBoolean, {before: true, after: true})('foo'));
+
+expectType<undefined>(debounceFn(stringToBoolean, {after: false})('foo'));
+expectError<boolean>(debounceFn(stringToBoolean, {after: false})('foo'));

--- a/readme.md
+++ b/readme.md
@@ -46,13 +46,19 @@ Default: `0`
 
 Time to wait until the `input` function is called.
 
-##### immediate
+##### before
 
 Type: `boolean`<br>
 Default: `false`
 
-Trigger the function on the leading edge instead of the trailing edge of the `wait` interval. For example, can be useful for preventing accidental double-clicks on a "submit" button from firing a second time.
+Trigger the function on leading edge of `wait` interval. For example, can be useful for preventing accidental double-clicks on a "submit" button from firing a second time.
 
+##### after
+
+Type: `boolean`<br>
+Default: `true`
+
+Trigger the function on trailing edge of `wait` interval.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -26,31 +26,12 @@ test('debounces a function', async t => {
 	t.is(count, 2);
 });
 
-test('before:false after:false options', async t => {
-	let count = 0;
-
-	const debounced = debounceFn(value => {
-		count++;
-		return value;
-	}, {
+test('before:false after:false options', t => {
+	t.throws(() => debounceFn(() => null, {
 		wait: 20,
 		before: false,
 		after: false
-	});
-
-	t.is(debounced(1), undefined);
-	t.is(debounced(2), undefined);
-	t.is(debounced(3), undefined);
-	t.is(count, 0);
-
-	await delay(100);
-	t.is(debounced(4), undefined);
-	t.is(debounced(5), undefined);
-	t.is(debounced(6), undefined);
-	t.is(count, 0);
-
-	await delay(200);
-	t.is(count, 0);
+	}), 'Both `before` and `after` are false, function wouldn\'t be called.');
 });
 
 test('before:true after:false options', async t => {

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ test('debounces a function', async t => {
 	t.is(count, 2);
 });
 
-test('immediate option', async t => {
+test('before:false after:false options', async t => {
 	let count = 0;
 
 	const debounced = debounceFn(value => {
@@ -34,12 +34,41 @@ test('immediate option', async t => {
 		return value;
 	}, {
 		wait: 20,
-		immediate: true
+		before: false,
+		after: false
+	});
+
+	t.is(debounced(1), undefined);
+	t.is(debounced(2), undefined);
+	t.is(debounced(3), undefined);
+	t.is(count, 0);
+
+	await delay(100);
+	t.is(debounced(4), undefined);
+	t.is(debounced(5), undefined);
+	t.is(debounced(6), undefined);
+	t.is(count, 0);
+
+	await delay(200);
+	t.is(count, 0);
+});
+
+test('before:true after:false options', async t => {
+	let count = 0;
+
+	const debounced = debounceFn(value => {
+		count++;
+		return value;
+	}, {
+		wait: 20,
+		before: true,
+		after: false
 	});
 
 	t.is(debounced(1), 1);
 	t.is(debounced(2), 1);
 	t.is(debounced(3), 1);
+	t.is(count, 1);
 
 	await delay(100);
 	t.is(debounced(4), 4);
@@ -49,6 +78,61 @@ test('immediate option', async t => {
 
 	await delay(200);
 	t.is(count, 2);
+});
+
+test('before:false after:true options', async t => {
+	let count = 0;
+
+	const debounced = debounceFn(value => {
+		count++;
+		return value;
+	}, {
+		wait: 20,
+		before: false,
+		after: true
+	});
+
+	t.is(debounced(1), undefined);
+	t.is(debounced(2), undefined);
+	t.is(debounced(3), undefined);
+	t.is(count, 0);
+
+	await delay(100);
+	t.is(debounced(4), 3);
+	t.is(debounced(5), 3);
+	t.is(debounced(6), 3);
+	t.is(count, 1);
+
+	await delay(200);
+	t.is(count, 2);
+});
+
+test('before:true after:true options', async t => {
+	let count = 0;
+
+	const debounced = debounceFn(value => {
+		count++;
+		return value;
+	}, {
+		wait: 20,
+		before: true,
+		after: true
+	});
+
+	t.is(debounced(1), 1);
+	t.is(debounced(2), 1);
+	t.is(debounced(3), 1);
+	t.is(count, 1);
+
+	await delay(100);
+	t.is(count, 2);
+	t.is(debounced(4), 4);
+	t.is(debounced(5), 4);
+	t.is(debounced(6), 4);
+	t.is(count, 3);
+
+	await delay(200);
+	t.is(count, 4);
 });
 
 test('.cancel() method', async t => {


### PR DESCRIPTION
Add before and after options, remove immediate option, fixes #5

Both `before` and `after` set to `true` lead to function which will never be executed and debounced version will always return `undefined`. Typed that for typescript, so should be easy to catch if it was a mistake, though don't see much sense in checking it at runtime.

Test `before:false after:true options` basically repeats what's tested in main `debounces a function` test, but still added it for clarity.