### PR TITLE
Add `maxWait` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,15 @@ declare namespace debounceFn {
 		readonly wait?: number;
 
 		/**
+		Maximum time to wait until the `input` function is called.
+		Only applies when after is true.
+		Disabled when 0
+
+		@default 0
+		*/
+		readonly maxWait?: number;
+
+		/**
 		Trigger the function on the leading edge of the `wait` interval.
 
 		For example, this can be useful for preventing accidental double-clicks on a "submit" button from firing a second time.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,18 @@
 declare namespace debounceFn {
 	interface Options {
 		/**
-		Time to wait until the `input` function is called.
+		Time in milliseconds to wait until the `input` function is called.
 
 		@default 0
 		*/
 		readonly wait?: number;
 
 		/**
-		Maximum time to wait until the `input` function is called.
-		Only applies when after is true.
+		Maximum time in milliseconds to wait between calls to the `input` function.
 		Disabled when 0
+
+		This can be used to limit the number of calls handled in a constant stream.
+		For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
 
 		@default 0
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,13 +8,12 @@ declare namespace debounceFn {
 		readonly wait?: number;
 
 		/**
-		Maximum time in milliseconds to wait between calls to the `input` function.
-		Disabled when 0
+		The maximum time the `input` function is allowed to be delayed before it's invoked.
 
-		This can be used to limit the number of calls handled in a constant stream.
+		This can be used to control the rate of calls handled in a constant stream.
 		For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
 
-		@default 0
+		@default Infinity
 		*/
 		readonly maxWait?: number;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,7 @@ export interface Options {
 	/**
 	The maximum time the `input` function is allowed to be delayed before it's invoked.
 
-	This can be used to control the rate of calls handled in a constant stream.
-	For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
+	This can be used to control the rate of calls handled in a constant stream. For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
 
 	@default Infinity
 	*/

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (inputFunction, options = {}) => {
 
 	const {
 		wait = 0,
-		maxWait = 0,
+		maxWait = Number.Infinity,
 		before = false,
 		after = true
 	} = options;
@@ -54,7 +54,7 @@ module.exports = (inputFunction, options = {}) => {
 		clearTimeout(timeout);
 		timeout = setTimeout(later, wait);
 
-		if (maxWait > 0 && !maxTimeout) {
+		if (maxWait > 0 && maxWait !== Number.Infinity && !maxTimeout) {
 			maxTimeout = setTimeout(maxLater, maxWait);
 		}
 

--- a/index.js
+++ b/index.js
@@ -45,14 +45,16 @@ module.exports = (inputFunction, options = {}) => {
 				timeout = undefined;
 			}
 
-			result = inputFunction.apply(context, arguments_);
+			if (after) {
+				result = inputFunction.apply(context, arguments_);
+			}
 		};
 
 		const shouldCallNow = before && !timeout;
 		clearTimeout(timeout);
 		timeout = setTimeout(later, wait);
 
-		if (maxWait > 0 && !maxTimeout && after) {
+		if (maxWait > 0 && !maxTimeout) {
 			maxTimeout = setTimeout(maxLater, maxWait);
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,7 @@ Default: `0` (disabled)
 
 The maximum time the `input` function is allowed to be delayed before it's invoked.
 
-This can be used to limit the number of calls handled in a constant stream.
-For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
+This can be used to limit the number of calls handled in a constant stream. For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
 
 ##### before
 

--- a/readme.md
+++ b/readme.md
@@ -41,14 +41,14 @@ Type: `object`
 Type: `number`\
 Default: `0`
 
-Time to wait until the `input` function is called.
+Time in milliseconds to wait until the `input` function is called.
 
 ##### maxWait
 
 Type: `number`\
 Default: `0` (disabled)
 
-Maximum time in milliseconds to wait between calls to the `input` function.
+The maximum time the `input` function is allowed to be delayed before it's invoked.
 
 This can be used to limit the number of calls handled in a constant stream.
 For example, a media player sending updates every few milliseconds but wants to be handled only once a second.

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,16 @@ Default: `0`
 
 Time to wait until the `input` function is called.
 
+##### maxWait
+
+Type: `number`\
+Default: `0` (disabled)
+
+Maximum time in milliseconds to wait between calls to the `input` function.
+
+This can be used to limit the number of calls handled in a constant stream.
+For example, a media player sending updates every few milliseconds but wants to be handled only once a second.
+
 ##### before
 
 Type: `boolean`\

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Time in milliseconds to wait until the `input` function is called.
 ##### maxWait
 
 Type: `number`\
-Default: `0` (disabled)
+Default: `Infinity`
 
 The maximum time the `input` function is allowed to be delayed before it's invoked.
 

--- a/test.js
+++ b/test.js
@@ -157,15 +157,18 @@ test('before:false after:true `maxWait` option', async t => {
 	});
 
 	t.is(debounced(1), undefined);
+	t.is(count, 0);
 	await delay(30);
 	t.is(count, 0);
 
 	t.is(debounced(2), undefined);
+	t.is(count, 0);
 	await delay(30);
 	t.is(count, 1);
 
 	t.is(debounced(3), 1);
 
+	t.is(count, 1);
 	await delay(200);
 	t.is(count, 2);
 });
@@ -190,12 +193,46 @@ test('before:true after:false `maxWait` option', async t => {
 	t.is(debounced(2), 1);
 	t.is(count, 1);
 	await delay(30);
+	t.is(count, 1);
 
 	t.is(debounced(3), 3);
 	t.is(count, 2);
 
 	await delay(50);
+	t.is(count, 2);
 
 	t.is(debounced(4), 4);
 	t.is(count, 3);
+});
+
+test('before:true after:true `maxWait` option', async t => {
+	let count = 0;
+
+	const debounced = debounceFn(value => {
+		count++;
+		return value;
+	}, {
+		wait: 40,
+		maxWait: 50,
+		after: true,
+		before: true
+	});
+
+	t.is(debounced(1), 1);
+	t.is(count, 1);
+	await delay(30);
+
+	t.is(debounced(2), 1);
+	t.is(count, 1);
+	await delay(30);
+	t.is(count, 2);
+
+	t.is(debounced(3), 3);
+	t.is(count, 3);
+
+	await delay(50);
+	t.is(count, 4);
+
+	t.is(debounced(4), 4);
+	t.is(count, 5);
 });

--- a/test.js
+++ b/test.js
@@ -143,7 +143,7 @@ test('.cancel() method', async t => {
 	t.is(count, 0);
 });
 
-test('debounces a function with maxWait', async t => {
+test('before:false after:true `maxWait` option', async t => {
 	let count = 0;
 
 	const debounced = debounceFn(value => {
@@ -151,7 +151,9 @@ test('debounces a function with maxWait', async t => {
 		return value;
 	}, {
 		wait: 40,
-		maxWait: 50
+		maxWait: 50,
+		after: true,
+		before: false
 	});
 
 	t.is(debounced(1), undefined);
@@ -166,4 +168,34 @@ test('debounces a function with maxWait', async t => {
 
 	await delay(200);
 	t.is(count, 2);
+});
+
+test('before:true after:false `maxWait` option', async t => {
+	let count = 0;
+
+	const debounced = debounceFn(value => {
+		count++;
+		return value;
+	}, {
+		wait: 40,
+		maxWait: 50,
+		after: false,
+		before: true
+	});
+
+	t.is(debounced(1), 1);
+	t.is(count, 1);
+	await delay(30);
+
+	t.is(debounced(2), 1);
+	t.is(count, 1);
+	await delay(30);
+
+	t.is(debounced(3), 3);
+	t.is(count, 2);
+
+	await delay(50);
+
+	t.is(debounced(4), 4);
+	t.is(count, 3);
 });

--- a/test.js
+++ b/test.js
@@ -142,3 +142,28 @@ test('.cancel() method', async t => {
 	t.is(debounced(3), undefined);
 	t.is(count, 0);
 });
+
+test('debounces a function with maxWait', async t => {
+	let count = 0;
+
+	const debounced = debounceFn(value => {
+		count++;
+		return value;
+	}, {
+		wait: 40,
+		maxWait: 50
+	});
+
+	t.is(debounced(1), undefined);
+	await delay(30);
+	t.is(count, 0);
+
+	t.is(debounced(2), undefined);
+	await delay(30);
+	t.is(count, 1);
+
+	t.is(debounced(3), 1);
+
+	await delay(200);
+	t.is(count, 2);
+});


### PR DESCRIPTION
This adds a `maxWait` option.

The intention is to ensure that the callback is fired after at most maxWait of time.

This is particularly useful in the following situation. Perhaps this is streaming data of an volume control changing, but the source is sending updates too often.
wait=100, maxWait=1000
With the debounce being called every ~50ms for 30s.
Without this, only one update will be processed at the very end, rather than one every second.
