### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"invoked"
 	],
 	"dependencies": {
-		"mimic-fn": "^3.0.0"
+		"mimic-fn": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^3.15.0",


### PR DESCRIPTION
`mimic-fn` [v4](https://github.com/sindresorhus/mimic-fn/releases) is ESM, while this package is still relying on the v3 version.